### PR TITLE
Added Deepsource - A company that pays Technical writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Dev Spotlight](https://www.devspotlight.com/jobs/) - Around $300-$500 per piece depending on length and content
   > Technical content production agency that works with many clients.
 
+- [Deepsource](https://deepsource.io/tech-writer/) - Around $150 per piece  
+  > Technical Content concerning code quality, code review and static analysis
+
 - [Digital Ocean](https://www.digitalocean.com/write-for-donations/) - Up to $400 per piece
   > Technical tutorials with code. Not limited to Digital Ocean products.
 


### PR DESCRIPTION
Deepsource pays $150 
Respond within a day 
and Pays Via paypal