### PR TITLE
Added: Guest blogging opportunity at Logical Clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Linode](https://www.linode.com/docs/contribute/) - Up to $300 per piece
   > Technical tutorials with code on Linux or Linode.
+  
+- [Logical Clocks](https://www.logicalclocks.com/job-positions/guest-blogger) - Pay-per-tutorial setting, GPU credits
+  > Technical tutorials with code on Data Engineering, Machine Learning, and ML Engineering
 
 - [LoginRadius](https://www.loginradius.com/blog/async/page/guest-blog) - Up to $200 per piece
   > Technical tutorials with code. Not limited to LoginRadius products.


### PR DESCRIPTION
I've added the Guest Bloggers program at Logical Clocks to the list. The writers can submit code demos and tech tutorials on the areas of Data Engineering, Machine Learning, and ML Engineering.