### PR TITLE
remove Clubhouse.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [Clubhouse.io](https://clubhouse.io/clubhouse-write-earn-give-program/) - Up to $600 per piece
-  > Technical tutorials and how-to guides. Pick from a list of possible articles.
-
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
 


### PR DESCRIPTION
The link of Clubhouse.io was actually taking to here (https://shortcut.com) and even though the website is working it was taking to a 404 page.