### PR TITLE
Permit.io writing program

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Paperspace](https://blog.paperspace.com/write-for-paperspace/) - $200-$300 per piece
   > Get paid to write articles about machine learning, data science, and more.
 
+- [Permit.io](https://io.permit.io/permit-content) - $400 per published article
+  >  Implement Permit.io into a demo application of your choice, create a piece of content about it, and get paid!
+
 - [Plural](https://www.plural.sh/blog/plurals-content-contribution-program/) - $300 per 1,000 word article
   > Get paid to write articles on, what you have built with Plural, application-specific deployment guides, and architectural comparisons of popular open-source tools against each other.
 


### PR DESCRIPTION
Added the Permit.io content creation program to the list.  Permit.io is an authorization-as-a-service provider that's quick and simple to implement. We’re looking for people who can implement Permit.io into their demo applications and create a piece of content about it!