### PR TITLE
remove inactive programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Amezmo](https://www.amezmo.com/write-for-amemzo) - $300 per article
   > Technical tutorials, guides, opinions and case studies on PHP hosting and general web development tutorials.
 
+- [AppSignal](https://blog.appsignal.com/write-for-us) - $300 per article
+  > Cover topics in full-stack web development.
+  
 - [Bugfender](https://bugfender.com/blog/write-for-us/) - Up to $500 per article
   > Mobile development, Frontend development, and any other dev focused content. Tutorials, guides, and tech articles.
   
@@ -39,6 +42,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Corellium](https://www.corellium.com/contributor-program) - $500-$1500 per article
   > Technical tutorials, guides, opinions and case studies on mobile application security.
+
+- [Draft.dev](https://draft.dev/write) - Pays $315-$578 per piece
+  > Technical content agency that works with many clients. Writers who are accepted will get an email every week and access to a writer portal with dozens of topics they can choose from.
 
 - [Egghead](https://egghead.io/write-for-egghead) - Pay unknown
   > Intermediate to advanced articles covering topics on web development.
@@ -141,6 +147,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [TestSigma](https://testsigma.com/testsigma-writers-program) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on testing automation.
+
+- [TheBotForge](https://www.thebotforge.io/guest-authors/) - up to £200 per article
+  > Technical tutorials, guides and case studies on conversational AI and NLP/NLP/Machine Learning.
 
 - [Topcoder](https://www.topcoder.com/thrive/articles/Submitting%20a%20Thrive%20Article) - $75 per piece
   > Tutorials, workshops and articles are accepted. Get paid to write about Competitive Programming, Data Science, Design, Development, QA and/or Gig Work.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/) - Pay unknown
   > Get paid to write about your favorite machine learning topics.
 
+- [Neverinstall](https://blog.neverinstall.com/neverinstall-technical-writer-program) - $100-$250 per article.
+  > Neverinstall invites developers to contribute to our knowledge library and develop content for the tech community. As we work on cutting-edge technologies, we call upon enthusiasts and passionate software developers to help us spread awareness through guides, blogs, tutorials, and more.
+  
 - [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
   > Technical tutorials and demos using Okta's products.
 
@@ -99,6 +102,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
+
+- [ruttl](https://ruttl.com/blog/write-for-us/) - INR 1 (~$0.012) per word
+  > Indian writers only. Writers can choose from a list of topics on UI/UX, web design and web development
 
 - [SaturnCloud](https://saturncloud.io/write-for-us/) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on Python and data science.
@@ -156,6 +162,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Tutorialspoint](https://www.tutorialspoint.com/about/tutorials_writing.htm) - Up to $500 per piece
   > In-depth tutorials on technical and business topics.
+
+- [Twilio](https://www.twilio.com/en-us/voices) - $650 per piece
+  > Technical tutorials that focuses on encouraging developers to build the future of communications.
 
 - [TypingDNA](https://www.typingdna.com/guest-author-program) - Up to $500 per piece
   > Technical articles/tutorials related to TypingDNA.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,8 @@ Paid writer programs usually have just enough of an incentive for people to get 
 
 A list of companies that have paid Developer Community Writer Programs.
 
-- [Abstract API](https://www.abstractapi.com/write-for-us) - $100 per article.
-  > Technical content and tutorials related to the APIs in their catalogue.
-
 - [Adeva](https://adevait.com/write-for-us) - $200+ per article
   > Technical guides, thought leadership content and resources for Engineering Managers.
-
-- [Agora](https://www.agora.io/en/agora-content-contributor-program/) - $250 per article
-  > Technical content and tutorials for the Agora community.
 
 - [AIConfig](https://forms.gle/MALE8ju94QWmYWVdA) - $75-$200 per article.
   > Technical content, tutorials, and building demo projects that include AIConfig (open-source project from LastMile AI).
@@ -19,47 +13,11 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Airbyte](https://airbyte.com/write-for-the-community) - $900 per article of about 1500 words.
   > Data engineering tutorials, tutorials that cover Airbyte use cases and features.
 
-- [Alan AI](https://forms.gle/VJ3gQ2tNWqd3pLq97) - $75-$200 per article.
-  > Technical content, tutorials, building demo projects, and how-to guides that includes Alan AI platform.
-
-- [Ambassador Labs](https://www.getambassador.io/write-for-us/) - $300 per article
-  > Technical tutorials, guides, opinions and case studies on Kubernetes and open source cloud native technologies.
-
 - [Amezmo](https://www.amezmo.com/write-for-amemzo) - $300 per article
   > Technical tutorials, guides, opinions and case studies on PHP hosting and general web development tutorials.
 
-- [Ant Media](https://antmedia.io/write-for-us-looking-for-technical-authors/) - $50-$150 per piece
-  > Articles on streaming technologies and trends (WebRTC, RTMP Protocol)
-
-- [Apify](https://apify.com/write-for-apify) - $150+ per article
-  > Cover tutorials about web scraping with Python, TypeScript, and JavaScript, browser automation, web RPA, and AI and machine learning in the context of collecting web data.
-
-- [AppSignal](https://blog.appsignal.com/write-for-us) - $300 per article
-  > Cover topics in full-stack web development.
-
-- [appypie](https://www.appypie.com/guest-post) - Up to $100 per piece
-  > Write blogs on a wide range of topics.
-
-- [Arctype](https://arctype.com/blog/contribute/) - $100+ per article
-  > Technical guides, case studies, and thought leadership on SQL and Databases.
-
-- [ Auth0's](https://auth0.com/apollo-program) - Up to $450 per article
-  > Write on a broad scope of topics: Identity & Security Mobile (Native & Cross Platform), Python, Electron, Java, and .NET.
-
-- [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvements)
-  > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
-  
-- [Betterstack](https://betterstack.com/community/write-for-us/) - $300 per article
-  > High-quality guides on building high-performance and scalable applications, observability, and DevOps
-
-- [Bejamas](https://bejamas.io/paid-writing-program/) - $250+ per article
-  > We welcome authors with real-world experience in modern web technologies. On our [blog](https://bejamas.io/blog/), we accept tutorials and practical guides, while our [discovery](https://bejamas.io/discovery/) section features overviews.
-
 - [Bugfender](https://bugfender.com/blog/write-for-us/) - Up to $500 per article
   > Mobile development, Frontend development, and any other dev focused content. Tutorials, guides, and tech articles.
-
-- [Chainstack Developer Hub](https://github.com/chainstack/developer-hub-content) - $200
-  > Web3 technical content with code. Tutorials, guides, and expository content.
   
 - [CircleCI](https://circleci.com/blog/guest-writer-program/) - $350-$600 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
@@ -69,9 +27,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
-
-- [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Pay unknown
-  > Technical articles about Flutter.
 
 - [Codiga](https://www.codiga.io/write-for-us/) - $100-$150 per piece
   > Technical articles focused on code quality.
@@ -84,18 +39,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Corellium](https://www.corellium.com/contributor-program) - $500-$1500 per article
   > Technical tutorials, guides, opinions and case studies on mobile application security.
-  
-- [Dev Spotlight](https://www.devspotlight.com/jobs/) - $300-$500 per piece depending on length and content
-  > Technical content production agency that works with many clients.
-
-- [Directus](https://docs.directus.io/blog/guest-author.html) - $200-$500 per article
-  > Cover advanced-level tutorials explaining how to use one or more Directus features.
-
-- [Dockship](https://dockship.io/articles) - $20
-  > Machine Learning and Data Science. You need to be signed in to be able to create content.
-
-- [Draft.dev](https://draft.dev/write) - Pays $315-$578 per piece
-  > Technical content agency that works with many clients. Writers who are accepted will get an email every week and access to a writer portal with dozens of topics they can choose from.
 
 - [Egghead](https://egghead.io/write-for-egghead) - Pay unknown
   > Intermediate to advanced articles covering topics on web development.
@@ -103,26 +46,8 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Every Developer Content Agency](https://everydeveloper.com/join/) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on software development.
 
-- [Fauna](https://github.com/fauna/write-with-fauna) - Up to $700 per piece
-  > Content focused on technical education around serverless development and FaunaDB.
-
-- [Giskard](https://www.giskard.ai/write-for-the-community) - $300-$400 per article
-  > Technical tutorials, guides, opinions and case studies on machine learning and AI.
-
 - [Hashnode Web3 Blog](https://web3.hashnode.com/contribute-to-the-web3-blog) - $250-$350 per article
   > Technical content and tutorials related to Web3.
-
-- [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece
-  > Technical tutorials with code about Hasura or GraphQL.
-
-- [Heartbeat by Comet](https://heartbeat.comet.ml/call-for-contributors-fee7f5b80f3e) - [over $150](https://www.youtube.com/watch?v=e_B0vt-eWPw) per piece
-  > Technical content related to Trends in machine learning research, explorations of new tools and libraries and data science.
-
-- [Hit Subscribe](https://www.hitsubscribe.com/apply-to-be-an-author/) - $100 per piece, $200 for 2x length and ghostwritten articles (Special articles).
-  > Technical content production agency that works with many clients.
-  
-- [Honeybadger](https://www.honeybadger.io/blog/write-for-us/) - From $500 per piece
-  > Ruby and Elixir tutorials with code. Pick from a list of possible articles.
 
 - [Hygraph](https://hygraph.com/write-for-hygraph) - Up to $300 per piece
   > Technical tutorials or blogs with code about Hygraph or GraphQL with Jamstack or tooling of your choice.
@@ -133,9 +58,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [IOD Content Agency](https://iamondemand.com/iod-talent-network/) - $300-$400 per article
   > Technical tutorials, guides, opinions and case studies on DevOps and software development.
 
-- [Invertase](https://invertase.io/authors-program) - Up to $250 per piece and up to $100 voucher for author of the month
-  > Technical tutorials or blogs with code about Dart & Flutter, Firebase, Firebase extensions, Software development, open source and web technologies
-
 - [Kestra](https://kestra.io/write-for-us) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on data orchestration and workflow optimization.
 
@@ -145,23 +67,14 @@ A list of companies that have paid Developer Community Writer Programs.
 - [LoginRadius](https://www.loginradius.com/blog/async/page/guest-blog) - Up to $200 per piece
   > Technical tutorials with code. Not limited to LoginRadius products.
 
-- [Magalix](https://www.magalix.com/the-sac-writers-club) - $200+ per piece
-  > Technical content and tutorials about DevSecOps, Cloud security, Kubernetes security.
-
 - [Magic](https://magic-fortmatic.typeform.com/to/Wgzsocor) - Up to $300 per piece
   > Technical tutorials on how to use Magic.link
 
 - [MagicPod](https://frost-act-be2.notion.site/MagicPod-Writers-Program-ea85c41d617943559a351f85c3add632) - Up to $200 per piece
   > Articles on various software testing topics, from Web Automation Testing, Mobile App Testing, Testing Strategies to Thought Leadership, as well as Cross Browser Testing
 
-- [MailSender](https://www.mailersend.com/write-for-us) - $300+ per article
-  > Technical tutorials, guides, opinions and case studies on transactional messaging and Mailsender integrations.
-
 - [Make Use Of](https://www.makeuseof.com/contributor/) - $120 per piece with performance benefits
   > Tutorials and features about consumer apps and software products.
-
-- [Mattermost](https://handbook.mattermost.com/contributors/contributors/ways-to-contribute/community-content-program) - Up to $500 per article
-  > Beginner to intermediate technical content including introductions and guides for useful libraries, programming environments, languages, and tech stacks.
   
 - [MetalBear](https://metalbear.co/writers-program/) - Up to $300 per article
   > Technical articles, guides, and tutorials on cloud software development, DevOps, Developer Experience, Platform Engineering, backend engineering.
@@ -172,47 +85,14 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/) - Pay unknown
   > Get paid to write about your favorite machine learning topics.
 
-- [Neverinstall](https://blog.neverinstall.com/neverinstall-technical-writer-program) - $100-$250 per article.
-  > Neverinstall invites developers to contribute to our knowledge library and develop content for the tech community. As we work on cutting-edge technologies, we call upon enthusiasts and passionate software developers to help us spread awareness through guides, blogs, tutorials, and more.
-
-- [Nimblebox.ai](https://nimblebox.ai/technical-writer-program) - $100 per article.
-  > The NimbleBox Technical Writer Program is a way for you to support the future of MLOps by writing technical articles.
-
 - [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
   > Technical tutorials and demos using Okta's products.
-
-- [OneSignal](https://onesignal.com/guest-author-program) - Up to $350 per article
-  > Technical content (blog post, videos) that align with OneSignal's content roadmap.
-  
-- [OpenReplay](https://medium.com/stackanatomy/write-for-us-ad11489bd7c3) - Up to $250 per article
-  > We’re always looking for talented authors that are willing to cover any and all topics that are of interest to front-end developers.
-
-- [Paperspace](https://blog.paperspace.com/write-for-paperspace/) - $200-$300 per piece
-  > Get paid to write articles about machine learning, data science, and more.
-
-- [Permit.io](https://io.permit.io/permit-content) - $400 per published article
-  >  Implement Permit.io into a demo application of your choice, create a piece of content about it, and get paid!
-
-- [Plural](https://www.plural.sh/blog/plurals-content-contribution-program/) - $300 per 1,000 word article
-  > Get paid to write articles on, what you have built with Plural, application-specific deployment guides, and architectural comparisons of popular open-source tools against each other.
 
 - [PHP Architect](https://www.phparch.com/editorial/write-for-us/) - $175 per piece
   > Thought leadership and technical articles about PHP.
 
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
-
-- [Refine](https://refine.dev/docs/contributing/) - $100-$150 per article
-  > They accept articles covering popular frontend technologies and UI enhancement. Articles         covering Refine's product and its applications.
-   
-- [RunX](https://blog.runx.dev/announcing-runxs-technical-writer-program-ea3790f0a80) - $150 for opinion pieces around DevOps and $200 for Tutorials
-  > Get paid to write about DevOps, cloud infrastructure, and Opta.
-  
-- [ruttl](https://ruttl.com/blog/write-for-us/) - INR 1 (~$0.012) per word
-  > Indian writers only. Writers can choose from a list of topics on UI/UX, web design and web development.
-
-- [Sanity.io](https://www.sanity.io/guest-authorship) - Up to $250 per piece
-  > Technical focused articles and how-to guides. Pick from a list of possible articles.
 
 - [SaturnCloud](https://saturncloud.io/write-for-us/) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on Python and data science.
@@ -244,12 +124,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Soshace](https://blog.soshace.com/write-for-us/) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [Sourcegraph](https://sourcegraph.com/community) - $250-500 per piece
-  > Technical posts about AI code assistants.
-
-- [SpinupWP](https://spinupwp.com/writers-program/) - $500-$1,000 per piece
-  > Technical articles on systems administration, caching, WordPress hosting, DevOps, site deployment and other server & WordPress-related topics. New articles, update existing articles or video tutorials/walkthroughs.
-
 - [SQLShack](https://www.sqlshack.com/about-us/) - $200 per piece
   > Technical focused articles on SQL Server and related technologies.
 
@@ -258,15 +132,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1) - $500 per piece
   > Software engineering focused articles. No tutorials and should be of interest to a wide range of developers.
-
-- [Storyblok](https://www.storyblok.com/tp/guest-writing-terms) - $200 per piece
-  > Articles across severless tech, perfomance optimization, Jamstack and Headless CMS, etc.
   
 - [Strapi](https://strapi.io/write-for-the-community) - Up to $200 per piece
   > Articles or tutorials with code covering use-cases, solutions and projects built with Strapi that include Vue, Open Source, JavaScript, GraphQL, Jamstack, React. Pick from a list of possible articles or pitch your own.
-
-- [TakeShape](https://www.takeshape.io/jobs/contributing-writer/) - Up to $300 per piece
-  > Web dev tutorials with code. General frontend topics including, React, JavaScript, GraphQL, Jamstack. Pick from a list of possible articles or pitch your own.
 
 - [Tech Beacon](https://techbeacon.com/write) - $400 per piece
   > Broad coverage of development, DevOps, QA and security.
@@ -274,17 +142,11 @@ A list of companies that have paid Developer Community Writer Programs.
 - [TestSigma](https://testsigma.com/testsigma-writers-program) - $300+ per article
   > Technical tutorials, guides, opinions and case studies on testing automation.
 
-- [TheBotForge](https://www.thebotforge.io/guest-authors/) - up to £200 per article
-  > Technical tutorials, guides and case studies on conversational AI and NLP/NLP/Machine Learning.
-
 - [Topcoder](https://www.topcoder.com/thrive/articles/Submitting%20a%20Thrive%20Article) - $75 per piece
   > Tutorials, workshops and articles are accepted. Get paid to write about Competitive Programming, Data Science, Design, Development, QA and/or Gig Work.
 
 - [Tutorialspoint](https://www.tutorialspoint.com/about/tutorials_writing.htm) - Up to $500 per piece
   > In-depth tutorials on technical and business topics.
-
-- [Twilio](https://www.twilio.com/voices) - $650 per piece
-  > Technical tutorials that focuses on encouraging developers to build the future of communications.
 
 - [TypingDNA](https://www.typingdna.com/guest-author-program) - Up to $500 per piece
   > Technical articles/tutorials related to TypingDNA.


### PR DESCRIPTION
This merge request aims to remove programs that are not currently active or have broken links.
Some of them are paused for now and that's fine. When they are open again, they can be added back but currently, their presence on this list is confusing and wastes people's time.

- Abstract API: Page not found
- Agora: Reroutes to homepage. Can't find their guest author program anywhere
- Alan AI: Form link is broken
- Ambassador: Not accepting guest posts
- Antmedia: Page not found
- Apify: Not accepting contributions
- Appsignal: Not sure they are accepting. Applied and never heard from them.
- Appypie - Inaccessible page
- Arctype - Page not found
- Auth0: Link to program doesn't show any sign up form and redirects to https://developer.auth0.com/
- Baeldung: Contributions are not currently open.
- Betterstack: Temporarily closed
- Bejamas: No link to apply
- Chainstacklabs: Unpaid
- Codemagic: Not accepting posts
- Devspotlight: Page not found
- Directus: Not accepting posts
- Dockship: Error page
- Draft.dev: Filled form but never got feedback
- Fauna: Closed
- Giskard: No link to apply.
- Hasura: Discontinued
- Heartbeat: Not accepting posts
- Hitsubscribe: Not accepting posts
- Honeybadger: Not accepting posts
- Iamondemand: Links lead to nowhere
- Invertase: Page not found
- Magalix: Page not found
- MailSender: Not accepting posts
- Mattermost: Submissions closed
- Neverinstall: Submissions closed
- Nimblebox: Not functional
- Typingdna: Last post by guest author is 2022
- Twilio: Submissions closed
- Botforge: Last blog was April 2024. Not replied my application
- Onesignal: Form not found
- Stackanatomy/OpenReplay: Not accepting posts
- Paperspace: Page not found
- Permit.io: Not accepting posts
- Plural.sh: No link to apply.
- Quicknode: Not accepting posts
- Refine - : No link to apply.
- Runx: Not accepting posts
- Sanity : Not accepting posts
- Soshace: No link to apply.
- Sourcegraph: No link to apply.
- Spinup: Submissions paused
- Storyblok: Submissions closed
- Takeshape: Page not found
- Okta: No link to apply.
- Techbeacon: No link to apply.
